### PR TITLE
Accept optional npm config key-value pairs. This enables --save, --save-dev, etc.

### DIFF
--- a/bin/irm
+++ b/bin/irm
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
 
 var irm = require('../');
-irm(process.cwd());
+var omit = require('object.omit');
+var argv = require('minimist')(process.argv.slice(2));
+
+irm(process.cwd(), omit(argv, '_'));

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ var installRequiredDependencies = function(path, opt) {
 
 	find(path, function(err, requires) {
 		npm.load({ loaded: false }, function() {
+			Object.keys(opt).forEach(function(o) {
+				npm.config.set(o, opt[o]);
+			});
 			npm.commands.install(path, requires);
 		});
 	});

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   },
   "homepage": "https://github.com/boo1ean/irm",
   "dependencies": {
-    "all-requires": "0.0.3"
+    "all-requires": "^0.0.3",
+    "minimist": "^1.1.0",
+    "npm": "^2.1.16",
+    "object.omit": "^0.2.1"
   }
 }


### PR DESCRIPTION
This addresses issue https://github.com/boo1ean/irm/issues/1.

It will you to call `irm` in code like so:

```js
irm('./app', { save: true });
irm('./test', { 'save-dev': true });
```

or though the cli:

```bash
$ cd project/app && irm --save
$ cd project/test && irm --save-dev
```