### PR TITLE
Prevent stdout spam by passing a noop callback to npm install.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var find = require('all-requires');
 var npm = require('npm');
+var noop = function() {};
 
 var installRequiredDependencies = function(path, opt) {
 	opt = opt || {};
@@ -9,7 +10,7 @@ var installRequiredDependencies = function(path, opt) {
 			Object.keys(opt).forEach(function(o) {
 				npm.config.set(o, opt[o]);
 			});
-			npm.commands.install(path, requires);
+			npm.commands.install(path, requires, noop);
 		});
 	});
 };


### PR DESCRIPTION
Me again :p It took me a while to work out what was going on, but if you don’t pass a callback to `npm.commands.install` it will spam stdout with a big ugly dependency array.