### PR TITLE
Don’t re-install requires by default.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,41 @@
 var find = require('all-requires');
+var pluck = require('object.pluck');
+var omit = require('object.omit');
+var async = require('async');
+var path = require('path');
 var npm = require('npm');
+var fs = require('fs');
 var noop = function() {};
 
-var installRequiredDependencies = function(path, opt) {
+var nodeModulePath = function(dir, filename) {
+	return path.join(dir, '/node_modules/', filename);
+};
+
+var installRequiredDependencies = function(dir, opt) {
 	opt = opt || {};
 
-	find(path, function(err, requires) {
+	var install = function(requires) {
 		npm.load({ loaded: false }, function() {
-			Object.keys(opt).forEach(function(o) {
+			Object.keys(omit(opt, 'reinstall')).forEach(function(o) {
 				npm.config.set(o, opt[o]);
 			});
-			npm.commands.install(path, requires, noop);
+			npm.commands.install(dir, requires, noop);
+		});
+	};
+ 
+	find(dir, function(err, requires) {
+		if (opt.reinstall) {
+			return install(requires);
+		}
+
+		async.filter(requires, function(module, next) {
+			fs.exists(nodeModulePath(dir, module), function(exists) {
+				next(!exists ? module : null);
+			});
+		}, function(missing) {
+			if (missing.length) {
+				install(missing);
+			}
 		});
 	});
 };

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
   "homepage": "https://github.com/boo1ean/irm",
   "dependencies": {
     "all-requires": "^0.0.4",
+    "async": "^0.9.0",
     "minimist": "^1.1.0",
     "npm": "^2.1.16",
-    "object.omit": "^0.2.1"
+    "object.omit": "^0.2.1",
+    "object.pluck": "^0.1.0"
   }
 }


### PR DESCRIPTION
This is a breaking change, but it seems like a saner default to me. I’m working on a project that uses native modules, so at the moment, every `irm` call triggers a re-build.