### PR TITLE
Use tilde range specifier for all-requires version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/boo1ean/irm",
   "dependencies": {
-    "all-requires": "^0.0.4",
+    "all-requires": "~0.0.4",
     "async": "^0.9.0",
     "minimist": "^1.1.0",
     "npm": "^2.1.16",


### PR DESCRIPTION
This lets `irm` use the latest patch version of `all-requires` ([see more info](https://nodesource.com/blog/semver-tilde-and-caret)).
